### PR TITLE
Accept group submissions

### DIFF
--- a/hashgrader.py
+++ b/hashgrader.py
@@ -7,36 +7,50 @@ from glob import iglob
 def grade(assignment, key, autopoints=100, fullscore=100, scorestring=str):
     try:
         json_files = [pos_json for pos_json in iglob(os.path.join('submission', '**', '*.json'), recursive=True)]
-    
+
+        # A submission may also contain source code, so a file actually named
+        # results.json wins over any other json that happens to be in there.
+        results_files = [f for f in json_files if os.path.basename(f).lower() == 'results.json']
+        if results_files:
+            json_files = results_files
+
         assert len(json_files) == 1, 'Expected exactly one json file, got ' + str(len(json_files)) + ': ' + str(json_files) + '.'
-    
+
         sub_file = json_files[0]
         with open(sub_file) as f:
             sub = json.load(f)
-    
+
         with open('submission_metadata.json') as f:
             meta = json.load(f)
-    
-        me = meta['users'][0]['email']
+
+        # For a group submission, meta['users'] holds every member of the
+        # group, and any one of their emails may be the one that was hashed.
+        emails = [u['email'] for u in meta['users']]
         se = sub['email']
-        assert me.lower() == se.lower(), 'Gradescope email ({}) and submission email ({}) did not match!'.format(me, se)
-    
+        matches = [e for e in emails if e.lower() == se.lower()]
+        assert matches, 'Submission email ({}) is not one of the submitting group members ({})!'.format(se, ', '.join(emails))
+
         assert sub['assignment'] == assignment, 'Submission from wrong homework (got {}, expected {}).'.format(sub['assignment'], assignment)
-    
+
+        # Hash with the email as it was typed on the student's machine: the
+        # match above is case-insensitive, but sha256 is not.
         m = hashlib.sha256()
         score_str = scorestring(sub['score'])
-        m.update((str(sub['assignment'])+str(me)+score_str+str(key)).encode('utf-8'))
+        m.update((str(sub['assignment'])+str(se)+score_str+str(key)).encode('utf-8'))
         assert m.hexdigest() == sub['hash'], "Hash mismatch! If you think you submitted a valid json file, report this to the course staff."
-    
+
         points = round(max(0, min(autopoints, autopoints*sub['score']/fullscore)), 1)
+        output = 'Submission Successful! You received ' + str(points) + '/' + str(autopoints) + ' autograder points.'
+        if len(emails) > 1:
+            output += ' (Scored from the run by ' + se + '.)'
         d = {'score': points,
-             'output': 'Submission Successful! You received ' + str(points) + '/' + str(autopoints) + ' autograder points.',
+             'output': output,
              'leaderboard': [{'name':'score', 'value':sub['score']}]}
-    
+
     except Exception as ex:
         d = {'score': 0, 'output': 'ERROR: '+str(ex)}
         print(str(ex))
-    
+
     finally:
         with open('results/results.json', 'w') as f:
             json.dump(d, f)

--- a/test/results/results.json
+++ b/test/results/results.json
@@ -1,0 +1,1 @@
+{"score": 27.3, "output": "Submission Successful! You received 27.3/100 autograder points.", "leaderboard": [{"name": "score", "value": 27.260595548871155}]}

--- a/test/rungrouptest.py
+++ b/test/rungrouptest.py
@@ -1,0 +1,79 @@
+# Exercises the group-submission path: a results.json hashed by one member is
+# accepted when any member of the group submits it.
+import sys, os, json, hashlib, shutil, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(HERE))
+from hashgrader import grade
+
+KEY = 'password'
+ASSIGNMENT = 'Lab-1'
+
+def hashed(assignment, email, score, key):
+    return hashlib.sha256((str(assignment)+str(email)+str(score)+str(key)).encode('utf-8')).hexdigest()
+
+def run(emails, sub, extra_files=()):
+    d = tempfile.mkdtemp()
+    os.makedirs(os.path.join(d, 'submission'))
+    os.makedirs(os.path.join(d, 'results'))
+    with open(os.path.join(d, 'submission', 'results.json'), 'w') as f:
+        json.dump(sub, f)
+    for name, content in extra_files:
+        with open(os.path.join(d, 'submission', name), 'w') as f:
+            f.write(content)
+    with open(os.path.join(d, 'submission_metadata.json'), 'w') as f:
+        json.dump({'users': [{'email': e} for e in emails]}, f)
+    cwd = os.getcwd()
+    try:
+        os.chdir(d)
+        grade(assignment=ASSIGNMENT, key=KEY, autopoints=50.0, fullscore=200)
+        with open(os.path.join('results', 'results.json')) as f:
+            return json.load(f)
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(d)
+
+def sub_for(email, score=100):
+    return {'assignment': ASSIGNMENT, 'email': email, 'score': score,
+            'hash': hashed(ASSIGNMENT, email, score, KEY)}
+
+group = ['a@colorado.edu', 'b@colorado.edu', 'c@colorado.edu']
+fails = []
+
+def check(name, cond, detail):
+    print(('PASS  ' if cond else 'FAIL  ') + name + ('' if cond else '  -> ' + str(detail)))
+    if not cond:
+        fails.append(name)
+
+r = run(group, sub_for('a@colorado.edu'))
+check('first member hashed', r['score'] == 25.0, r)
+
+r = run(group, sub_for('c@colorado.edu'))
+check('last member hashed', r['score'] == 25.0, r)
+
+r = run(group, sub_for('C@Colorado.EDU'))
+check('case-insensitive match still hashes', r['score'] == 25.0, r)
+
+r = run(group, sub_for('outsider@colorado.edu'))
+check('non-member rejected', r['score'] == 0 and 'not one of' in r['output'], r)
+
+r = run(['a@colorado.edu'], sub_for('a@colorado.edu'))
+check('solo submission still works', r['score'] == 25.0, r)
+
+r = run(group, sub_for('a@colorado.edu', 500))
+check('score capped at autopoints', r['score'] == 50.0, r)
+
+r = run(group, sub_for('a@colorado.edu'),
+        extra_files=[('Project.json', '{}'), ('solve.m', 'x = A\\b;')])
+check('stray json alongside results.json ignored', r['score'] == 25.0, r)
+
+bad = sub_for('a@colorado.edu')
+bad['score'] = 200
+r = run(group, bad)
+check('tampered score rejected', r['score'] == 0 and 'Hash mismatch' in r['output'], r)
+
+r = run(group, sub_for('a@colorado.edu'))
+check('leaderboard value present', r['leaderboard'][0]['value'] == 100, r)
+
+print('\n' + ('ALL PASS' if not fails else 'FAILURES: ' + ', '.join(fails)))
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
Gradescope lists every member of a group in `submission_metadata.json`, but the email check only ever looked at `users[0]`, so a submission by anyone other than the first member was rejected. It now matches the submission email against every member.

Two related fixes came along with it:

- The hash is computed from the email **as the student typed it** rather than the one Gradescope reports. The match has been case-insensitive since #3, but sha256 is not, so a student who typed a different case cleared the check and then failed on the hash.
- A file actually named `results.json` wins over any other json in the submission, so an assignment that also collects source code does not trip the "expected exactly one json file" check.

`test/rungrouptest.py` covers each group member, case variants, a non-member, a tampered score, the stray-json case, the solo path, and the score cap. The existing `test/runtest.py` still passes.

Not yet merged into the `v0.1` branch that deployed `setup.sh` files fetch from — this is being shakedown-tested on ASEN 3502 Lab 1 with a vendored copy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)